### PR TITLE
build: replace old gradle-build-action

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -16,9 +16,7 @@ jobs:
         with:
           java-version: "17"
           distribution: "temurin"
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v2.1.2
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3.1.0
+        uses: gradle/actions/setup-gradle@v5
       - name: Execute Gradle build
         run: ./gradlew build


### PR DESCRIPTION
This replaces old gradle-build-action with new setup-gradle action.

See: https://github.com/gradle/gradle-build-action and https://github.com/gradle/actions/tree/main/setup-gradle

This also removes usage of wrapper-validation-action, since this also deprecated and validation is included in new setup-gradle action. See: https://github.com/gradle/actions/tree/main/wrapper-validation