### PR TITLE
chore: update spring dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id "org.springframework.boot" version '3.4.13'
+	id "org.springframework.boot" version '3.5.10'
 	id "io.spring.dependency-management" version '1.1.7'
 	id 'java'
 	id 'jacoco'
@@ -43,7 +43,7 @@ tasks.register('integrationTest', Test) {
 //check.dependsOn integrationTest
 
 ext {
-	set('springCloudVersion', "2024.0.3")
+	set('springCloudVersion', "2025.0.1")
     set('apacheCommonsCsv', "1.14.1")
 }
 


### PR DESCRIPTION
Since Spring Boot 3.4.x and Spring Cloud 2024.0.x as no OSS support anymore, update to latest Spring Boot 3.5.x and related Spring Cloud 2025.0.x.