### PR TITLE
test: add initial approval tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ out/
 
 /deploy/.env
 #/gradle/wrapper/gradle-wrapper.jar
+
+# ApprovalTests
+**/*.received.xml

--- a/build.gradle
+++ b/build.gradle
@@ -22,11 +22,21 @@ sourceSets {
 		compileClasspath += sourceSets.main.output
 		runtimeClasspath += sourceSets.main.output
 	}
+
+    snapshotTest {
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
+
+        compileClasspath += sourceSets.test.output
+        runtimeClasspath += sourceSets.test.output
+    }
 }
 
 configurations {
 	intTestImplementation.extendsFrom implementation
 	intTestRuntimeOnly.extendsFrom runtimeOnly
+
+    snapshotTestImplementation.extendsFrom implementation
 }
 
 tasks.register('integrationTest', Test) {
@@ -36,6 +46,15 @@ tasks.register('integrationTest', Test) {
 	testClassesDirs = sourceSets.intTest.output.classesDirs
 	classpath = sourceSets.intTest.runtimeClasspath
 	shouldRunAfter test
+}
+
+tasks.register('snapshotTest', Test) {
+    description = 'Runs snapshot tests.'
+    group = 'verification'
+
+    testClassesDirs = sourceSets.snapshotTest.output.classesDirs
+    classpath = sourceSets.snapshotTest.runtimeClasspath
+    shouldRunAfter test
 }
 
 //check.dependsOn integrationTest
@@ -83,6 +102,13 @@ dependencies {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
 	intTestImplementation 'org.assertj:assertj-core'
+
+    // snapshot tests
+    snapshotTestImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
+    snapshotTestImplementation 'org.assertj:assertj-core'
+    snapshotTestImplementation "com.approvaltests:approvaltests:26.7.1"
 }
 
 dependencyManagement {
@@ -97,6 +123,10 @@ test {
 
 integrationTest {
 	useJUnitPlatform()
+}
+
+snapshotTest {
+    useJUnitPlatform()
 }
 
 jacoco {

--- a/src/main/java/de/unimarburg/diz/kafkagenetictomtbxml/configuration/MetadataConfigurationProperties.java
+++ b/src/main/java/de/unimarburg/diz/kafkagenetictomtbxml/configuration/MetadataConfigurationProperties.java
@@ -1,7 +1,9 @@
 package de.unimarburg.diz.kafkagenetictomtbxml.configuration;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "metadata")
@@ -12,6 +14,8 @@ public class MetadataConfigurationProperties {
     private NgsReports ngsReports;
 
     @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Builder
     public static class NgsReports {
         private String kitManufacturer;

--- a/src/snapshotTest/java/de/unimarburg/diz/kafkagenetictomtbxml/mapper/OnkostarDataMapperTest.java
+++ b/src/snapshotTest/java/de/unimarburg/diz/kafkagenetictomtbxml/mapper/OnkostarDataMapperTest.java
@@ -1,0 +1,91 @@
+package de.unimarburg.diz.kafkagenetictomtbxml.mapper;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator;
+import de.unimarburg.diz.kafkagenetictomtbxml.configuration.HgncConfigurationProperties;
+import de.unimarburg.diz.kafkagenetictomtbxml.configuration.MetadataConfigurationProperties;
+import de.unimarburg.diz.kafkagenetictomtbxml.model.MtbPatientInfo;
+import de.unimarburg.diz.kafkagenetictomtbxml.model.mhGuide.MHGuide;
+import org.approvaltests.Approvals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = {
+        PatientMapper.class,
+        ErkrankungMapper.class,
+        TudokMapper.class,
+        UnterformularSVMapper.class,
+        UnterformularCNVMapper.class,
+        UnterformularRNAFusionMapper.class,
+        UnterformularKomplexBiomarkerMapperMSI.class,
+        UnterformularKomplexBiomarkerMapperTMB.class,
+        MetadataConfigurationProperties.class,
+        MetadataConfigurationProperties.NgsReports.class,
+        HgncConfigurationProperties.class
+})
+@TestPropertySource(locations = "classpath:application-test.yml")
+class OnkostarDataMapperTest {
+
+    OnkostarDataMapper mapper;
+    ObjectMapper jsonMapper;
+    XmlMapper xmlMapper;
+
+    @BeforeEach
+    void setUp(
+            @Autowired final PatientMapper patientMapper,
+            @Autowired final ErkrankungMapper erkrankungMapper,
+            @Autowired final TudokMapper tudokMapper
+    ) {
+        this.mapper = new OnkostarDataMapper(
+                patientMapper,
+                erkrankungMapper,
+                tudokMapper
+        );
+        this.jsonMapper = new ObjectMapper();
+        this.xmlMapper = new XmlMapper();
+        xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true);
+        xmlMapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    private static MtbPatientInfo defaultMtbPatientInfo() {
+        MtbPatientInfo info = new MtbPatientInfo();
+        info.setPatientenId("0123456");
+        info.setTumorId("1");
+        info.setSid("2");
+        info.setGuid("00000000-0001-9999-ffff-000000000001");
+        info.setRevision("3");
+        info.setMigReferenzTumorId("4");
+        info.setEinsendennummer("H/2026/10000");
+        info.setDiagnoseDatum(Date.from(Instant.parse("2026-01-01T00:00:00.000Z")));
+        return info;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"empty-mhguide.json"})
+    void shouldMapToOnkostarXml(String mhGuideFile) throws IOException {
+        var inputStream = Objects.requireNonNull(this.getClass().getClassLoader().getResourceAsStream("mhguide/" + mhGuideFile)).readAllBytes();
+        var mhGuide = this.jsonMapper.readValue(inputStream, MHGuide.class);
+
+        var onkostarDaten = this.mapper.createOnkostarDaten(mhGuide, defaultMtbPatientInfo());
+        // Fixed
+        onkostarDaten.setSendeDatum("2026-01-01T12:00:00.000Z");
+        var output = this.xmlMapper.writeValueAsString(onkostarDaten);
+
+        Approvals.verify(output, Approvals.NAMES.withParameters(mhGuideFile).forFile().withExtension(".xml"));
+    }
+
+}

--- a/src/snapshotTest/java/de/unimarburg/diz/kafkagenetictomtbxml/mapper/PackageSettings.java
+++ b/src/snapshotTest/java/de/unimarburg/diz/kafkagenetictomtbxml/mapper/PackageSettings.java
@@ -1,0 +1,5 @@
+package de.unimarburg.diz.kafkagenetictomtbxml.mapper;
+
+public class PackageSettings {
+    public static String UseApprovalSubdirectory = "approvals";
+}

--- a/src/snapshotTest/java/de/unimarburg/diz/kafkagenetictomtbxml/mapper/approvals/OnkostarDataMapperTest.shouldMapToOnkostarXml.empty-mhguide.json.approved.xml
+++ b/src/snapshotTest/java/de/unimarburg/diz/kafkagenetictomtbxml/mapper/approvals/OnkostarDataMapperTest.shouldMapToOnkostarXml.empty-mhguide.json.approved.xml
@@ -1,0 +1,128 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<OnkostarDaten>
+  <Titel/>
+  <SendendeOrganisation>
+    <Bezeichnung/>
+    <Kennung/>
+  </SendendeOrganisation>
+  <SendeDatum>2026-01-01T12:00:00.000Z</SendeDatum>
+  <DokumentId>1</DokumentId>
+  <DokumentVersion>1</DokumentVersion>
+  <Inhalt>
+    <PatientenDaten>
+      <Patient>
+        <ExportID>1</ExportID>
+        <PatientenId>0123456</PatientenId>
+        <Personendaten>
+          <AktuelleAdresse/>
+        </Personendaten>
+        <PidGesperrt>false</PidGesperrt>
+      </Patient>
+      <Dokumentation>
+        <Erkrankung>
+          <ExportID>2</ExportID>
+          <TumorId>1</TumorId>
+          <SID>2</SID>
+          <GUID>00000000-0001-9999-ffff-000000000001</GUID>
+          <Revision>3</Revision>
+          <MigReferenzTumorId>4</MigReferenzTumorId>
+        </Erkrankung>
+        <TudokEintrag>
+          <ExportID>3</ExportID>
+          <ErkrankungExportID>2</ErkrankungExportID>
+          <TumorId>1</TumorId>
+          <DokumentierendeFachabteilung>
+            <FachabteilungKennung/>
+            <EinrichtungKennung/>
+          </DokumentierendeFachabteilung>
+          <StartDatum></StartDatum>
+          <FormularName>OS.Molekulargenetik</FormularName>
+          <FormularVersion>1</FormularVersion>
+          <Prozedurtyp>Beobachtung</Prozedurtyp>
+          <Eintrag Feldname="Dokumentation">
+            <Wert>ERW</Wert>
+            <Filterkategorie>{}</Filterkategorie>
+            <Version>OS.MolDokumentation.v1</Version>
+            <Kurztext>Erweitert</Kurztext>
+          </Eintrag>
+          <Eintrag Feldname="AnalyseID"/>
+          <Eintrag Feldname="AnalyseMethode"/>
+          <Eintrag Feldname="AnalyseMethoden">
+            <Filterkategorie>{}</Filterkategorie>
+            <Version>OS.MolDiagMethode.v1</Version>
+          </Eintrag>
+          <Eintrag Feldname="ArtDerSequenzierung">
+            <Filterkategorie>{}</Filterkategorie>
+            <Version>OS.MolDiagSequenzierung.v1</Version>
+          </Eintrag>
+          <Eintrag Feldname="ArtinsituHybridisierung">
+            <Wert></Wert>
+            <Filterkategorie></Filterkategorie>
+            <Version></Version>
+            <Kurztext></Kurztext>
+          </Eintrag>
+          <Eintrag Feldname="Befund"/>
+          <Eintrag Feldname="Bemerkung"/>
+          <Eintrag Feldname="Blocknummer"/>
+          <Eintrag Feldname="Datum">
+            <Genauigkeit>exact</Genauigkeit>
+          </Eintrag>
+          <Eintrag Feldname="DurchfuehrendeOE"/>
+          <Eintrag Feldname="Einsendenummer">
+            <Wert>H/2026/10000</Wert>
+          </Eintrag>
+          <Eintrag Feldname="Entnahmedatum"/>
+          <Eintrag Feldname="Entnahmemethode">
+            <Filterkategorie></Filterkategorie>
+          </Eintrag>
+          <Eintrag Feldname="ErgebnisMSI">
+            <Wert></Wert>
+            <Filterkategorie>{}</Filterkategorie>
+          </Eintrag>
+          <Eintrag Feldname="GenetischeVeraenderung"/>
+          <Eintrag Feldname="Genexpressionstests"/>
+          <Eintrag Feldname="HRD">
+            <Filterkategorie>{}</Filterkategorie>
+          </Eintrag>
+          <Eintrag Feldname="ICDO3Lokalisation">
+            <Filterkategorie></Filterkategorie>
+          </Eintrag>
+          <Eintrag Feldname="InternExtern">
+            <Filterkategorie>{}</Filterkategorie>
+            <Version>OS.OrtDurchfuehrung.v1</Version>
+          </Eintrag>
+          <Eintrag Feldname="KomplexeBiomarker"/>
+          <Eintrag Feldname="GenetischeVeraenderung"/>
+          <Eintrag Feldname="MolekulargenetischeUntersuchung"/>
+          <Eintrag Feldname="Panel"/>
+          <Eintrag Feldname="ProbeID"/>
+          <Eintrag Feldname="Probenmaterial">
+            <Wert></Wert>
+            <Version>OS.Probenmaterial.v1</Version>
+            <Kurztext></Kurztext>
+          </Eintrag>
+          <Eintrag Feldname="Projekt">
+            <Wert>ZPM,</Wert>
+            <Version>OS.MolDiag.Projekte.v1</Version>
+          </Eintrag>
+          <Eintrag Feldname="ReferenzGenom">
+            <Version>OS.MolSeqGenom.v1</Version>
+          </Eintrag>
+          <Eintrag Feldname="SeqKitHersteller">
+            <Version>OS.MolDiag.KitHersteller.v1</Version>
+            <Kurztext>Archer</Kurztext>
+          </Eintrag>
+          <Eintrag Feldname="SeqKitTyp"/>
+          <Eintrag Feldname="SeqPipeline"/>
+          <Eintrag Feldname="Sequenziergeraet">
+            <Version>OS.MolDiag.Sequenziergerät.v1</Version>
+            <Kurztext>Illumina NovaSeq 6000</Kurztext>
+          </Eintrag>
+          <Eintrag Feldname="Tumorzellgehalt"/>
+          <Revision>1</Revision>
+          <BearbeitungStatus>2</BearbeitungStatus>
+        </TudokEintrag>
+      </Dokumentation>
+    </PatientenDaten>
+  </Inhalt>
+</OnkostarDaten>

--- a/src/snapshotTest/resources/application-test.yml
+++ b/src/snapshotTest/resources/application-test.yml
@@ -1,0 +1,24 @@
+metadata:
+  ngsReports:
+    kitManufacturer: ${KIT_MANUFACTURER:Archer}
+    sequencer: ${SEQUENCER:Illumina NovaSeq 6000}
+    referenceGenome: ${REFERENCE_GENOME:GRCh37}
+    sequencingType: ${SEQUENCING_TYPE:PanelKit}
+    sequencingTypeShort: ${SEQUENCING_TYPE_SHORT:Panel}
+    interpolationSystem: ${INTERPOLATION_SYSTEM:MH Guide}
+    reportedFocality: ${REPORTED_FOCALITY:complete}
+    panelVP: ${PANEL_VP:VP-CST}
+    panelVPCP: ${PANEL_VP_CP:VP-CST+FP-PST}
+    seqKitTypVP: ${SEQKITTYP_VP:VP-CST}
+    seqPipelineVP: ${SEQPIPELINE_VP:urn:Marburg:VP:CST:1.0:MHGuide:6.3.0}
+    seqKitTypVPCP: ${SEQKITTYP_VPCP:VP-CST+FP-PST}
+    seqPipelineVPCP: ${SEQPIPELINE_VPCP:urn:Marburg:VP:CST:1.0:FP:PST:1.0:MHGuide:6.3.0}
+    fachabteilungKennung: ${FACHABTEILUNGKENNUNG:ITCCC}
+    einrichtungKennung: ${EINRICHTUNGKENNUNG:CCCUMR}
+    durchfuehrendeOE: ${DURCHFUEHRENDEOE:CCCUMR}
+    durchfuehrendeOEKurzText: ${DURCHFUEHRENDEOE_KURZTEXT:CCC Marburg}
+    internExternWert: ${INTERNEXTERN_WERT:M}
+    internExternKurztext: ${INTERNEXTERN_KURZTEXT:Meine Einrichtung}
+    analyseMethoden: ${ANALYSE_METHODE:S,KOMPBIO}
+    classificationName: ${CLASSIFICATION_NAME:Likely pathogenic,Pathogenic}
+    oncogenicClassificationName: ${ONCOGENIC_CLASSIFICATION_NAME:Likely oncogenic,Oncogenic}

--- a/src/snapshotTest/resources/mhguide/empty-mhguide.json
+++ b/src/snapshotTest/resources/mhguide/empty-mhguide.json
@@ -1,0 +1,8 @@
+{
+  "DATASET_VERSION_STRING": "Testversion 1",
+  "GENERAL": {},
+  "VARIANT_LONG_LIST": [],
+  "BIOMARKERS": {
+    "NOTABLE_BIOMARKERS": []
+  }
+}


### PR DESCRIPTION
Ziel ist das Sicherstellen, dass für eine definierte Eingabe aus Onkostar und MHGuide die vorgesehenen XML-Daten erzeugt werden.